### PR TITLE
Do not build & run unit tests

### DIFF
--- a/.github/workflows/track_minetest.yml
+++ b/.github/workflows/track_minetest.yml
@@ -32,11 +32,11 @@ jobs:
           ./push-revs.sh    # sets DID_PUSH
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Checkout minetest
+      # Checkout Luanti
       - uses: actions/checkout@v4
         if: ${{ env.DID_PUSH == 'true' }}
         with:
-          repository: '${{ github.repository_owner }}/minetest'
+          repository: '${{ github.repository_owner }}/luanti'
           ref: ${{ env.MINETEST_REV }}
           path: 'minetest'
       - name: Install deps

--- a/.github/workflows/track_minetest.yml
+++ b/.github/workflows/track_minetest.yml
@@ -58,7 +58,8 @@ jobs:
           CMAKE_BUILD_TYPE: "Release"
           CMAKE_BUILD_SERVER: FALSE
           CMAKE_ENABLE_GETTEXT: FALSE
-          CMAKE_FLAGS: "-DBUILD_BENCHMARKS=TRUE"
+          # Do not build tests: Tests may add spam to the benchmark output, letting parsing fail.
+          CMAKE_FLAGS: "-DBUILD_BENCHMARKS=TRUE -DBUILD_UNITTESTS=FALSE"
       - name: Run Benchmarks
         if: ${{ env.DID_PUSH == 'true' }}
         run: |


### PR DESCRIPTION
Fixes the problem of unit tests spamming benchmark output, making it unparseable. Also makes things a bit leaner.

CI on the main Luanti repo already ensures that these tests pass on sufficiently similar configurations.